### PR TITLE
Change route for video bookmarks

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
   <section class="bookmarked-videos">
     <h1>Bookmarked Segments</h1>
       <% user.bookmarked_videos.each do |video| %>
-        <p class="video"><%= link_to video.title, video_path(video) %></p>
+        <p class="bookmarked-video"><%= link_to video.title, tutorial_path(video.tutorial) %></p>
       <% end %>
   </section>
   <% if current_user.token %>

--- a/spec/features/user/user_can_see_bookmarked_videos_spec.rb
+++ b/spec/features/user/user_can_see_bookmarked_videos_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe "As a logged in user" do
 
       within ".bookmarked-videos" do
         expect(page).to have_content("Bookmarked Segments")
-        expect(page.all(".video").count).to eq(2)
-        expect(page.all(".video")[0]).to have_link(video1.title)
-        expect(page.all(".video")[1]).to have_link(video2.title)
+        expect(page.all(".bookmarked-video").count).to eq(2)
+        expect(page.all(".bookmarked-video")[0]).to have_link(video1.title)
+        expect(page.all(".bookmarked-video")[1]).to have_link(video2.title)
       end
     end
   end


### PR DESCRIPTION
This PR
-Refactors video bookmarks to use tutorials_path , not video_path