### PR TITLE
Add GitHub name and ID

### DIFF
--- a/app/controllers/github/sessions_controller.rb
+++ b/app/controllers/github/sessions_controller.rb
@@ -1,7 +1,9 @@
 class Github::SessionsController < ApplicationController
   def update
     token = request.env['omniauth.auth']['credentials']['token']
-    current_user.update(token: token)
+    github_id = request.env['omniauth.auth']['uid']
+    github_name = request.env['omniauth.auth']['info']['name']
+    current_user.update(token: token, github_id: github_id, github_name: github_name )
     redirect_to dashboard_path
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -52,7 +52,7 @@
   <section class='friends'>
     <h1>Your Friends</h1>
     <% user.friends.each do |friend| %>
-      <%= "#{friend.first_name} #{friend.last_name}" %>
+      <%= "#{friend.github_name}" %>
     <% end %>
 
   </section>

--- a/db/migrate/20190709160217_add_githubname_to_users.rb
+++ b/db/migrate/20190709160217_add_githubname_to_users.rb
@@ -1,0 +1,5 @@
+class AddGithubnameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :github_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_07_184716) do
+ActiveRecord::Schema.define(version: 2019_07_09_160217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2019_07_07_184716) do
     t.datetime "updated_at", null: false
     t.string "token"
     t.integer "github_id"
+    t.string "github_name"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/spec/features/user/user_can_add_a_friend_spec.rb
+++ b/spec/features/user/user_can_add_a_friend_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "webmock_helper"
 
 describe "when " do
-  it 'user can sign in' do
+  it 'user can add a friend in' do
     user1 = create(:user, token: ENV['GITHUB_OAUTH_TOKEN'] )
     user2 = create(:user, github_id: nil)
     user3 = create(:user, github_id: 35322570, first_name: "Patrick", last_name: "Duvall") #Patrick

--- a/spec/features/user/user_can_add_a_friend_spec.rb
+++ b/spec/features/user/user_can_add_a_friend_spec.rb
@@ -5,7 +5,7 @@ describe "when " do
   it 'user can add a friend in' do
     user1 = create(:user, token: ENV['GITHUB_OAUTH_TOKEN'] )
     user2 = create(:user, github_id: nil)
-    user3 = create(:user, github_id: 35322570, first_name: "Patrick", last_name: "Duvall") #Patrick
+    user3 = create(:user, github_id: 35322570, github_name: "Patrick-Duvall") #Patrick
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
 
@@ -24,7 +24,7 @@ describe "when " do
     expect(user1.friends.count).to eq(1)
 
     within '.friends' do
-      expect(page).to have_content("#{user3.first_name} #{user3.last_name}")
+      expect(page).to have_content(user3.github_name)
     end
 
     within '.github-followers' do

--- a/spec/features/user/user_can_connect_via_github_spec.rb
+++ b/spec/features/user/user_can_connect_via_github_spec.rb
@@ -9,19 +9,26 @@ describe "as a user" do
     end
 
     it "I can connect via github" do
-
+      # WebMock.allow_net_connect!
       OmniAuth.config.mock_auth[:github] = {
+        'uid' => '1234',
+        'info' => {
+          'name' => 'mock_name'
+        },
         'credentials' => {
           'token' => 'mock_token'
         }}
-      user = create(:user)
+      user = create(:user, )
       user_facade = UserShowFacade.new(user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       visit dashboard_path
       expect(page).to_not have_css(".github")
       click_link("Connect with GitHub")
       expect(current_path).to eq(dashboard_path)
+      save_and_open_page
       expect(user.token).to eq('mock_token')
+      expect(user.github_id.to_s).to eq('1234')
+      expect(user.github_name).to eq('mock_name')
       expect(page).to have_css(".github")
     end
   end


### PR DESCRIPTION
This PR
-Updates the OAuth to also pull users GitHub id and name.
-Adds a migration to add github_name to Users table. Make sure to run this migration.
-Updates dashboard to show friends by GitHub name.