### PR TITLE
Email activation cleanup

### DIFF
--- a/app/views/activation_mailer/activate.html.erb
+++ b/app/views/activation_mailer/activate.html.erb
@@ -1,2 +1,2 @@
 
-Hello <%= @user.first_name.capitalize %>, Youre getting this email because you recently created an account on brownfield_of_sorrow.com. <%= link_to "Click here to activate your account", user_activation_url(@user) %>.
+Hello <%= @user.first_name.capitalize %>, Youre getting this email because you recently created an account on Brownfield of Sorrow. <%= link_to "Click here to activate your account", user_activation_url(@user) %>.

--- a/app/views/activation_mailer/activate.text.erb
+++ b/app/views/activation_mailer/activate.text.erb
@@ -1,1 +1,1 @@
-Hello <%= @user.first_name.capitalize %>, Youre getting this email because you recently created an account on brownfield_of_sorrow.com. <%= link_to "Click here to activate your account", user_activation_url(@user) %>.
+Hello <%= @user.first_name.capitalize %>, Youre getting this email because you recently created an account on Brownfield of Sorrow. <%= link_to "Click here to activate your account", user_activation_url(@user) %>.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,4 +95,16 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  #Set production Active mailer config
+  config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      address:              'smtp.sendgrid.net',
+      port:                 '587',
+      domain:               'brownfield-of-sorrow.herokuapp.com',
+      user_name:            ENV["SENDGRID_USERNAME"],
+      password:             ENV["SENDGRID_PASSWORD"],
+      authentication:       'plain',
+      enable_starttls_auto: true
+    }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,7 @@ Rails.application.configure do
       address:              'smtp.sendgrid.net',
       port:                 '587',
       domain:               'brownfield-of-sorrow.herokuapp.com',
+      host:                 "brownfield-of-sorrow.herokuapp.com",
       user_name:            ENV["SENDGRID_USERNAME"],
       password:             ENV["SENDGRID_PASSWORD"],
       authentication:       'plain',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
 
   #Set production Active mailer config
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { :host => "brownfield-of-sorrow.herokuapp.com"}
+  config.action_mailer.default_url_options = { :host => "https://brownfield-of-sorrow.herokuapp.com"}
     config.action_mailer.smtp_settings = {
       address:              'smtp.sendgrid.net',
       port:                 '587',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,11 +98,11 @@ Rails.application.configure do
 
   #Set production Active mailer config
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { :host => "brownfield-of-sorrow.herokuapp.com"}
     config.action_mailer.smtp_settings = {
       address:              'smtp.sendgrid.net',
       port:                 '587',
       domain:               'brownfield-of-sorrow.herokuapp.com',
-      host:                 "brownfield-of-sorrow.herokuapp.com",
       user_name:            ENV["SENDGRID_USERNAME"],
       password:             ENV["SENDGRID_PASSWORD"],
       authentication:       'plain',

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,13 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+#Set Active mailer test environment
+  config.action_mailer.default_url_options = { :host => "localhost:3000"}
+  config.action_mailer.delivery_method = :test
+
+
+
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,6 +116,6 @@ m3_tutorial.videos.create!(
   'position' => 6
 )
 
-User.create!(email: 'admin@example.com', first_name: 'Bossy', last_name: 'McBosserton', password: 'password', role: :admin)
+User.create!(email: 'admin@example.com', first_name: 'Bossy', last_name: 'McBosserton', password: 'password', role: :admin, active: true)
 
-User.create!(email: 'user@example.com', first_name: 'User', last_name: 'McUser', password: 'password', token: ENV['GITHUB_OAUTH_TOKEN'])
+User.create!(email: 'user@example.com', first_name: 'User', last_name: 'McUser', password: 'password', token: ENV['GITHUB_OAUTH_TOKEN'], active: true)

--- a/spec/features/user/user_authenticates_via_email_spec.rb
+++ b/spec/features/user/user_authenticates_via_email_spec.rb
@@ -12,15 +12,15 @@ describe "As a visitor" do
     fill_in "user_last_name", with: 'last_name'
     fill_in "user_password", with: 'password'
     fill_in "user_password_confirmation", with: 'password'
-    click_button "Create Account"
+    expect { click_button "Create Account" }
+      .to change { ActionMailer::Base.deliveries.count }.by(1)
+    user = User.last
     expect(current_path).to eq(dashboard_path)
     expect(page).to have_content("Logged in as first_name last_name")
     expect(page).to have_content("This account has not yet been activated. Please check your email")
-    user = User.last
     expect(user.active?).to eq(false)
     expect(page).to have_content("Status: Inactive")
-    #Ask
-    #implement mailer unit test
+    #Email view logic part in mailer/activation_spec.rb
     visit user_activation_path(user)
     user.reload
     expect(current_path).to eq(dashboard_path)

--- a/spec/mailers/activation_spec.rb
+++ b/spec/mailers/activation_spec.rb
@@ -1,5 +1,19 @@
 require "rails_helper"
 
-RSpec.describe ActivationMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+
+
+  describe ActivationMailer do
+    it "checks email content" do
+      user = create(:user)
+      email = ActivationMailer.activate(user, user.email).deliver_now
+      expect(email.from).to eq(["sorrow@brownfield.com"])
+      expect(email.to).to eq([user.email])
+      expect(email.subject).to eq("Welcome to Sorrow #{user.first_name}.")
+
+      expect(email.body.encoded.include?("<a href=\"http://localhost:3000/user/activation/#{user.id}\">")).to eq(true)
+      html_email = Capybara.string(email.body.encoded)
+
+      expect(html_email).to have_link("Click here to activate your account")
+    end
+
+  end


### PR DESCRIPTION
This PR 
-Adds test for email on account activation
-Buffs user sends an email spec
-Makes test environment tweaks
-Minorly reformats email